### PR TITLE
Gossip mode fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,4 +8,3 @@
 - [ ] Add deployment infra: config-file and kubernetes resource definitions
 - [ ] Snapshot node state to persistent storage and reload on crash
 - [ ] Add docs
-

--- a/src/bin/colibri-admin.rs
+++ b/src/bin/colibri-admin.rs
@@ -1,7 +1,7 @@
 //! Colibri cluster administration tool
 //!
 //! Sends internal TCP messages to cluster nodes for administrative operations.
-//! Not exposed via public HTTP API - uses direct TCP transport.
+//! Not exposed via public HTTP API; uses direct TCP transport.
 //!
 //! # Examples
 //! ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,7 +128,6 @@ pub struct Cli {
         help = "Number of peers to gossip to per round (default 1"
     )]
     pub gossip_fanout: usize,
-
 }
 
 impl Cli {

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -14,6 +14,13 @@ use crate::settings;
 /// Distributed request counter using CRDT PN-counters
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct DistributedRequestCounter {
+    /// Origin metadata: the node that first created this counter.
+    ///
+    /// IMPORTANT: this field is **not** consulted when performing local writes.
+    /// The owning `DistributedBucket` holds `writer_node_id` separately, and all
+    /// mutation methods below take the writer identity as an explicit parameter.
+    /// Mixing these up would violate the GCounter single-writer-per-actor invariant
+    /// under concurrent cross-node updates.
     pub node_id: NodeId,
     refills: PNCounter<NodeId>,
     requests: PNCounter<NodeId>,
@@ -30,18 +37,22 @@ impl DistributedRequestCounter {
             vclock: VClock::new(),
         }
     }
-    fn expire_op_steps(&mut self, op: &InternalPnCounterOp) {
+
+    /// Apply expiration decrements as the given `writer`. The caller is responsible
+    /// for passing the local node's identity — never the counter's origin `node_id`,
+    /// which may belong to a remote node if this bucket was adopted via gossip.
+    fn expire_op_steps(&mut self, writer: NodeId, op: &InternalPnCounterOp) {
         match op {
             InternalPnCounterOp::Fills(steps) => {
-                let op = self.refills.dec_many(self.node_id, *steps);
+                let op = self.refills.dec_many(writer, *steps);
                 self.refills.apply(op);
             }
             InternalPnCounterOp::Requests(steps) => {
-                let op = self.requests.dec_many(self.node_id, *steps);
+                let op = self.requests.dec_many(writer, *steps);
                 self.requests.apply(op);
             }
         }
-        let op = self.vclock.inc(self.node_id);
+        let op = self.vclock.inc(writer);
         self.vclock.apply(op);
     }
 
@@ -164,9 +175,18 @@ pub struct DistributedBucketExternal {
 /// Used when receiving gossiped state from other nodes
 /// when we've never seen this client before.
 impl DistributedBucketExternal {
-    fn bucket(&self) -> DistributedBucket {
+    /// Adopt a gossiped bucket into local state.
+    ///
+    /// `local_node_id` must be the receiving limiter's node id. It becomes the
+    /// adopted bucket's `writer_node_id`, so any subsequent local mutations write
+    /// into this node's own PNCounter actor slot rather than the sender's.
+    /// The origin `node_id` is preserved from the gossip message so that
+    /// `DistributedBucketLimiter::expire_keys` continues to refuse to GC buckets
+    /// this node did not create.
+    fn bucket(&self, local_node_id: NodeId) -> DistributedBucket {
         DistributedBucket {
             node_id: self.node_id,
+            writer_node_id: local_node_id,
             counter: self.counter.clone(),
             requests: Vec::new(),
             last_call: Utc::now().timestamp_millis(),
@@ -177,7 +197,16 @@ impl DistributedBucketExternal {
 
 #[derive(Clone, Debug)]
 struct DistributedBucket {
+    /// Origin identity: the node that first created this bucket. Used by
+    /// `DistributedBucketLimiter::expire_keys` to refuse GC of buckets adopted
+    /// from peers (we cannot trust foreign timestamps for expiration decisions).
     pub node_id: NodeId,
+    /// Writer identity: the PNCounter actor slot this node writes into for this
+    /// bucket. Always the local limiter's node id, regardless of whether the
+    /// bucket was created locally or adopted from a gossip peer. Every call
+    /// into `DistributedRequestCounter` mutation methods must pass this value
+    /// as the writer — never `counter.node_id`, which may be a remote origin.
+    pub writer_node_id: NodeId,
     pub counter: DistributedRequestCounter,
     // internal state only: timestamps
     requests: Vec<InternalRequestEntry>,
@@ -211,12 +240,13 @@ impl DistributedBucket {
         let mut entries_to_remove = Vec::new();
         for (idx, entry) in self.requests.iter().enumerate() {
             if now_ms - (entry.timestamp_ms) > expiration_threshold_ms {
-                // Expire this entry
+                // Expire this entry. Decrements go to the local writer slot —
+                // never to `counter.node_id`, which may point at a remote origin.
                 debug!(
                     "Expiring entry {:?} from bucket for node {}: timestamp_ms={}, now_ms={}",
                     entry, self.node_id, entry.timestamp_ms, now_ms
                 );
-                self.counter.expire_op_steps(&entry.op);
+                self.counter.expire_op_steps(self.writer_node_id, &entry.op);
                 entries_to_remove.push(idx);
             }
         }
@@ -245,8 +275,12 @@ impl DistributedBucket {
 
 impl Bucket for DistributedBucket {
     fn new(max_calls: u32, node_id: NodeId) -> Self {
+        // Local creation: this node is both the origin (for GC) and the writer
+        // (for CRDT actor slot). The two become different only after adoption
+        // via `DistributedBucketExternal::bucket`.
         let mut instance = Self {
             node_id,
+            writer_node_id: node_id,
             counter: DistributedRequestCounter::new(node_id),
             requests: Vec::new(),
             last_call: Utc::now().timestamp_millis(),
@@ -291,7 +325,10 @@ impl Bucket for DistributedBucket {
             timestamp_ms: self.last_call,
             vclock: self.vclock(),
         });
-        self.counter.inc_refills(self.counter.node_id, steps);
+        // Writes must go to the local writer slot. Using `counter.node_id` here
+        // would attribute writes to a remote origin on adopted buckets, which
+        // GCounter::merge would then silently drop via its per-actor max.
+        self.counter.inc_refills(self.writer_node_id, steps);
         debug!("Updated bucket after adding tokens: {:?}", self.counter);
         self.last_call = Utc::now().timestamp_millis();
         self
@@ -303,7 +340,8 @@ impl Bucket for DistributedBucket {
             timestamp_ms: Utc::now().timestamp_millis(),
             vclock: self.vclock(),
         });
-        self.counter.inc_request(self.counter.node_id);
+        // See `add_tokens_to_bucket` — mutate the local writer slot, not the origin.
+        self.counter.inc_request(self.writer_node_id);
         self
     }
 
@@ -420,7 +458,7 @@ impl DistributedBucketLimiter {
     pub fn gossip_delta_state(&self) -> Vec<DistributedBucketExternal> {
         let guard = self.node_counters.pin();
 
-        // Phase 1: collect buckets that have changed since last gossip
+        // 1: collect buckets that have changed since last gossip
         let result: Vec<DistributedBucketExternal> = guard
             .iter()
             .filter_map(|(client_id, bucket)| {
@@ -432,7 +470,11 @@ impl DistributedBucketLimiter {
             })
             .collect();
 
-        // Phase 2: advance the gossip watermark for each included bucket
+        // 2: advance the gossip watermark for each included bucket.
+        // The || branch is the "insert if absent" path; in practice it should
+        // not fire here because we just iterated over the live entries. If it
+        // does, adopt the bucket with *this* limiter as the writer.
+        let local_node_id = self.node_id;
         for ext in &result {
             guard.update_or_insert_with(
                 ext.client_id.clone(),
@@ -441,7 +483,7 @@ impl DistributedBucketLimiter {
                     b.mark_gossiped();
                     b
                 },
-                || ext.bucket(),
+                || ext.bucket(local_node_id),
             );
         }
 
@@ -458,6 +500,7 @@ impl DistributedBucketLimiter {
     }
 
     pub fn accept_delta_state(&mut self, delta: &[DistributedBucketExternal]) {
+        let local_node_id = self.node_id;
         for incoming_bucket in delta.iter() {
             self.node_counters.pin().update_or_insert_with(
                 incoming_bucket.client_id.clone(),
@@ -468,7 +511,7 @@ impl DistributedBucketLimiter {
                         .merge(incoming_bucket.counter.clone());
                     existing_counter
                 },
-                || incoming_bucket.bucket(),
+                || incoming_bucket.bucket(local_node_id),
             );
         }
     }
@@ -816,9 +859,76 @@ mod tests {
         assert_eq!(external.client_id, "test_client");
         assert_eq!(external.node_id, node_id);
 
-        // Convert back to internal format
-        let restored_bucket = external.bucket();
+        // Convert back to internal format (as if adopted by the same node).
+        let restored_bucket = external.bucket(node_id);
         assert_eq!(restored_bucket.node_id, node_id);
+        assert_eq!(restored_bucket.writer_node_id, node_id);
         assert_eq!(restored_bucket.counter.tokens(), bucket.counter.tokens());
+    }
+
+    /// Regression test for safety issue: writer identity.
+    ///
+    /// When a bucket is adopted from a gossip peer, subsequent local mutations
+    /// must attribute their CRDT writes to the LOCAL node's actor slot, not the
+    /// sender's. Under concurrent writes at both nodes, the GCounter max-merge
+    /// would otherwise silently drop one side's updates.
+    #[test]
+    fn test_adopted_bucket_writes_do_not_clobber_origin_slot() {
+        let node_a = node_id();
+        let node_b = NodeName::from("b").node_id();
+
+        // Node A creates a bucket for a client and consumes one token.
+        // Use the bucket API directly (not the limiter) so wall-clock refills
+        // don't contaminate the exact-count assertion below.
+        let mut bucket_a = DistributedBucket::new(100, node_a);
+        bucket_a.decrement(); // A local: 1 request
+
+        // Simulate B adopting A's bucket via gossip. Before the safety bug fix this
+        // step would copy A's `counter.node_id` into B's bucket and silently
+        // route all of B's future writes into slot A of the PNCounter.
+        let external = bucket_a.to_external("test_client");
+        let mut bucket_b = external.bucket(node_b);
+
+        // Post-adoption invariants: origin preserved for GC, writer is local.
+        assert_eq!(bucket_b.node_id, node_a, "origin must be preserved");
+        assert_eq!(
+            bucket_b.writer_node_id, node_b,
+            "writer must be the local (adopting) node"
+        );
+
+        // Concurrent writes: both A and B process additional requests against
+        // their own replicas before any further gossip.
+        bucket_a.decrement(); // A local: 2 total
+        bucket_a.decrement(); // A local: 3 total
+        bucket_b.decrement(); // B local: 1 new request (on top of the adopted state)
+
+        // Gossip B's state back to A and merge.
+        let external_from_b = bucket_b.to_external("test_client");
+        bucket_a.counter.merge(external_from_b.counter);
+
+        // Total requests counted across the cluster:
+        //   1 (A's original, already in both replicas) + 2 (A's new) + 1 (B's new) = 4
+        // With seed refills = 100, net tokens after merge must be 100 - 4 = 96.
+        //
+        // With safety bug present, B's decrement landed in slot A. Node A's own slot A
+        // reached 3 requests locally, while B's slot A reached 2 (1 inherited + 1 new).
+        // merge = max(3, 2) = 3 → buggy net tokens = 97.
+        let tokens_after_merge = bucket_a.tokens_to_u32();
+        assert_eq!(
+            tokens_after_merge, 96,
+            "expected 96 tokens after 3 writes from A and 1 from B; \
+             got {}. An off-by-one here is the regression signature.",
+            tokens_after_merge
+        );
+
+        // Symmetric check: merging A's post-mutation state into B should yield
+        // the same total (idempotent, commutative).
+        let external_from_a = bucket_a.to_external("test_client");
+        bucket_b.counter.merge(external_from_a.counter);
+        assert_eq!(
+            bucket_b.tokens_to_u32(),
+            96,
+            "both replicas must converge to the same token count"
+        );
     }
 }

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -1,5 +1,7 @@
 //! Distributed token bucket using CRDT for eventual consistency
-use chrono::Utc;
+use std::sync::OnceLock;
+use std::time::Instant;
+
 use crdts::{CmRDT, CvRDT, PNCounter, ResetRemove, VClock};
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
@@ -10,6 +12,28 @@ use tracing::debug;
 use crate::limiters::token_bucket::Bucket;
 use crate::node::NodeId;
 use crate::settings;
+
+/// Monotonic millisecond clock for all elapsed-time decisions in `DistributedBucket`.
+///
+/// Backed by `std::time::Instant`, which is guaranteed not to go backwards
+/// regardless of NTP corrections, leap seconds, or operator clock resets.
+/// The epoch is anchored at the first call (effectively process start) and is
+/// process-local — values are not meaningful across process restarts or node
+/// boundaries. That is fine: `DistributedBucket` state is in-memory only, and
+/// the fields that use this clock (`last_call`, `InternalRequestEntry::timestamp_ms`)
+/// are never included in the gossip wire format.
+///
+/// `TokenBucket` intentionally retains wall-clock time because its `last_call`
+/// field *is* serialized and imported by other nodes in cluster mode, where
+/// cross-node timestamp comparability matters.
+static PROCESS_START: OnceLock<Instant> = OnceLock::new();
+
+fn monotonic_ms() -> i64 {
+    PROCESS_START
+        .get_or_init(Instant::now)
+        .elapsed()
+        .as_millis() as i64
+}
 
 /// Distributed request counter using CRDT PN-counters
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
@@ -192,7 +216,7 @@ impl DistributedBucketExternal {
             max_calls,
             counter: self.counter.clone(),
             requests: Vec::new(),
-            last_call: Utc::now().timestamp_millis(),
+            last_call: monotonic_ms(),
             // Initialise the watermark to the incoming state rather than VClock::new().
             // A freshly-adopted bucket has nothing local to re-broadcast: the
             // original sender already gossiped it. Only local writes that arrive
@@ -231,7 +255,7 @@ struct DistributedBucket {
 
 impl DistributedBucket {
     pub fn can_expire(&self, expiration_threshold_ms: i64) -> bool {
-        let now_ms = Utc::now().timestamp_millis();
+        let now_ms = monotonic_ms();
         for entry in self.requests.iter() {
             if now_ms - (entry.timestamp_ms) <= expiration_threshold_ms {
                 // Found an entry that is still valid; cannot expire
@@ -250,7 +274,7 @@ impl DistributedBucket {
     }
 
     pub fn expire_entries(&mut self, expiration_threshold_ms: i64) {
-        let now_ms = Utc::now().timestamp_millis();
+        let now_ms = monotonic_ms();
         let mut entries_to_remove = Vec::new();
         for (idx, entry) in self.requests.iter().enumerate() {
             if now_ms - (entry.timestamp_ms) > expiration_threshold_ms {
@@ -303,7 +327,7 @@ impl Bucket for DistributedBucket {
             max_calls,
             counter: DistributedRequestCounter::new(node_id),
             requests: Vec::new(),
-            last_call: Utc::now().timestamp_millis(),
+            last_call: monotonic_ms(),
             last_gossiped_vclock: VClock::new(),
         }
     }
@@ -319,12 +343,12 @@ impl Bucket for DistributedBucket {
         self.expire_entries(expiration_threshold_ms);
 
         // Same token replenishment logic as TokenBucket
-        let diff_ms: i64 = Utc::now().timestamp_millis() - self.last_call;
+        let now_ms = monotonic_ms();
+        let diff_ms: i64 = now_ms - self.last_call;
         // For this algorithm we arbitrarily do not trust intervals less than 5ms,
         // so we only *add* tokens if the diff is greater than that.
-        let diff_ms: i32 = diff_ms as i32;
         debug!("Token bucket diff_ms: {}", diff_ms);
-        if diff_ms < 5i32 {
+        if diff_ms < 5i64 {
             // no-op
             debug!("Not adding tokens to bucket: diff_ms < 5ms");
             return self;
@@ -332,15 +356,19 @@ impl Bucket for DistributedBucket {
         // Tokens are added at the token rate,
         // but for distributed bucket, we only add whole tokens
         // let participants: usize = self.vclock().dots.len();
-        let tokens_to_add: f64 = rate_limit_settings.token_rate_milliseconds() * f64::from(diff_ms);
+        let tokens_to_add: f64 = rate_limit_settings.token_rate_milliseconds() * (diff_ms as f64);
         let steps = tokens_to_add.trunc() as u64;
         debug!(
             "Adding tokens to bucket: diff_ms={}, tokens_to_add={} as steps={}",
             diff_ms, tokens_to_add, steps
         );
+        // Stamp the fill entry with the current time, not the previous last_call.
+        // Using self.last_call here would give the entry a stale timestamp, causing
+        // expire_entries to immediately remove fills that were just recorded when
+        // the elapsed gap exceeds the expiration threshold.
         self.requests.push(InternalRequestEntry {
             op: InternalPnCounterOp::Fills(steps),
-            timestamp_ms: self.last_call,
+            timestamp_ms: now_ms,
             vclock: self.vclock(),
         });
         // Writes must go to the local writer slot. Using `counter.node_id` here
@@ -348,14 +376,14 @@ impl Bucket for DistributedBucket {
         // GCounter::merge would then silently drop via its per-actor max.
         self.counter.inc_refills(self.writer_node_id, steps);
         debug!("Updated bucket after adding tokens: {:?}", self.counter);
-        self.last_call = Utc::now().timestamp_millis();
+        self.last_call = now_ms;
         self
     }
 
     fn decrement(&mut self) -> &mut Self {
         self.requests.push(InternalRequestEntry {
             op: InternalPnCounterOp::Requests(1),
-            timestamp_ms: Utc::now().timestamp_millis(),
+            timestamp_ms: monotonic_ms(),
             vclock: self.vclock(),
         });
         // See `add_tokens_to_bucket` — mutate the local writer slot, not the origin.
@@ -706,13 +734,13 @@ mod tests {
         // Add entries with different ages
         bucket.requests.push(InternalRequestEntry {
             op: InternalPnCounterOp::Requests(1),
-            timestamp_ms: Utc::now().timestamp_millis() - 2000, // Old
+            timestamp_ms: monotonic_ms() - 2000, // Old
             vclock: bucket.vclock(),
         });
 
         bucket.requests.push(InternalRequestEntry {
             op: InternalPnCounterOp::Fills(1),
-            timestamp_ms: Utc::now().timestamp_millis() - 200, // Recent
+            timestamp_ms: monotonic_ms() - 200, // Recent
             vclock: bucket.vclock(),
         });
 

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -499,6 +499,21 @@ impl DistributedBucketLimiter {
             .map(|counter| counter.to_external(client_id))
     }
 
+    /// Return the full CRDT state for all known clients, regardless of whether
+    /// each bucket has been gossiped since its last update.
+    ///
+    /// Used for anti-entropy: when a peer requests a full sync, we send everything
+    /// we have so they can merge it idempotently. Unlike `gossip_delta_state`, this
+    /// does NOT advance the gossip watermark — the regular delta loop continues
+    /// normally after an anti-entropy exchange.
+    pub fn full_state_dump(&self) -> Vec<DistributedBucketExternal> {
+        self.node_counters
+            .pin()
+            .iter()
+            .map(|(client_id, bucket)| bucket.to_external(client_id))
+            .collect()
+    }
+
     pub fn accept_delta_state(&mut self, delta: &[DistributedBucketExternal]) {
         let local_node_id = self.node_id;
         for incoming_bucket in delta.iter() {
@@ -930,5 +945,79 @@ mod tests {
             96,
             "both replicas must converge to the same token count"
         );
+    }
+
+    /// `full_state_dump` must return all buckets regardless of whether they have
+    /// been gossiped since their last update, unlike `gossip_delta_state` which
+    /// skips watermark-current buckets.
+    #[test]
+    fn test_full_state_dump_returns_all_buckets() {
+        let node_a = node_id();
+        let settings = test_settings();
+        let mut limiter = DistributedBucketLimiter::new(node_a, settings);
+
+        limiter.limit_calls_for_client("client_1".to_string());
+        limiter.limit_calls_for_client("client_2".to_string());
+
+        // After gossip_delta_state advances the watermarks, those buckets are
+        // excluded from the next delta call.
+        let delta = limiter.gossip_delta_state();
+        assert_eq!(delta.len(), 2, "both buckets should appear in first delta");
+
+        let delta_again = limiter.gossip_delta_state();
+        assert_eq!(
+            delta_again.len(),
+            0,
+            "no new ops since last gossip — delta should be empty"
+        );
+
+        // But full_state_dump must still return everything for anti-entropy.
+        let dump = limiter.full_state_dump();
+        assert_eq!(
+            dump.len(),
+            2,
+            "full_state_dump must return all buckets regardless of watermark"
+        );
+        let client_ids: Vec<&str> = dump.iter().map(|b| b.client_id.as_str()).collect();
+        assert!(client_ids.contains(&"client_1"));
+        assert!(client_ids.contains(&"client_2"));
+    }
+
+    /// Anti-entropy: a node that received state via gossip and then went idle should
+    /// be able to recover that state after a `StateRequest`/`full_state_dump` exchange.
+    #[test]
+    fn test_full_state_dump_used_for_anti_entropy_recovery() {
+        let node_a = node_id();
+        let node_b = NodeName::from("b").node_id();
+        let settings = test_settings();
+
+        let mut limiter_a = DistributedBucketLimiter::new(node_a, settings.clone());
+        let mut limiter_b = DistributedBucketLimiter::new(node_b, settings);
+
+        // Node A processes requests for two clients.
+        limiter_a.limit_calls_for_client("alice".to_string());
+        limiter_a.limit_calls_for_client("alice".to_string());
+        limiter_a.limit_calls_for_client("bob".to_string());
+
+        // Simulate UDP packet loss: node B never receives A's delta gossip.
+        // Node B has no knowledge of alice or bob.
+        assert_eq!(limiter_b.full_state_dump().len(), 0);
+
+        // Anti-entropy: B sends a StateRequest; A responds with full_state_dump.
+        // (In production this round-trip happens over UDP; here we test the
+        // limiter-layer semantics directly.)
+        let full_state = limiter_a.full_state_dump();
+        assert_eq!(full_state.len(), 2, "A should have 2 clients");
+
+        limiter_b.accept_delta_state(&full_state);
+
+        // After recovery B should see both clients with the same token counts as A.
+        let alice_a = limiter_a.check_calls_remaining_for_client(&"alice".to_string());
+        let alice_b = limiter_b.check_calls_remaining_for_client(&"alice".to_string());
+        assert_eq!(alice_a, alice_b, "alice's quota must match after anti-entropy");
+
+        let bob_a = limiter_a.check_calls_remaining_for_client(&"bob".to_string());
+        let bob_b = limiter_b.check_calls_remaining_for_client(&"bob".to_string());
+        assert_eq!(bob_a, bob_b, "bob's quota must match after anti-entropy");
     }
 }

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -183,17 +183,20 @@ impl DistributedBucketExternal {
     /// The origin `node_id` is preserved from the gossip message so that
     /// `DistributedBucketLimiter::expire_keys` continues to refuse to GC buckets
     /// this node did not create.
-    fn bucket(&self, local_node_id: NodeId) -> DistributedBucket {
+    /// `max_calls` is the limiter's configured capacity. It is stored locally on
+    /// the bucket and never written into the CRDT (no immortal seed tokens).
+    fn bucket(&self, local_node_id: NodeId, max_calls: u32) -> DistributedBucket {
         DistributedBucket {
             node_id: self.node_id,
             writer_node_id: local_node_id,
+            max_calls,
             counter: self.counter.clone(),
             requests: Vec::new(),
             last_call: Utc::now().timestamp_millis(),
             // Initialise the watermark to the incoming state rather than VClock::new().
             // A freshly-adopted bucket has nothing local to re-broadcast: the
             // original sender already gossiped it. Only local writes that arrive
-            //  *after* adoption should trigger a push.
+            // *after* adoption should trigger a push.
             last_gossiped_vclock: self.counter.vclock.clone(),
         }
     }
@@ -211,6 +214,13 @@ struct DistributedBucket {
     /// into `DistributedRequestCounter` mutation methods must pass this value
     /// as the writer — never `counter.node_id`, which may be a remote origin.
     pub writer_node_id: NodeId,
+    /// The configured capacity for this bucket. Kept as a local constant and
+    /// never written into the CRDT (no immortal seed tokens).
+    ///
+    /// `tokens_to_u32()` returns `max_calls + counter.tokens()` so the full
+    /// capacity is visible at the API level without polluting gossip state.
+    /// All nodes must agree on this value via their rate-limit configuration.
+    pub max_calls: u32,
     pub counter: DistributedRequestCounter,
     // internal state only: timestamps
     requests: Vec<InternalRequestEntry>,
@@ -282,16 +292,20 @@ impl Bucket for DistributedBucket {
         // Local creation: this node is both the origin (for GC) and the writer
         // (for CRDT actor slot). The two become different only after adoption
         // via `DistributedBucketExternal::bucket`.
-        let mut instance = Self {
+        //
+        // Do NOT write max_calls into the CRDT as a seed refill. The
+        // capacity is stored as the local `max_calls` field and added as a
+        // constant offset in `tokens_to_u32`. This prevents the seed from
+        // living forever in gossip state as untracked, un-ageable CRDT tokens.
+        Self {
             node_id,
             writer_node_id: node_id,
+            max_calls,
             counter: DistributedRequestCounter::new(node_id),
             requests: Vec::new(),
             last_call: Utc::now().timestamp_millis(),
             last_gossiped_vclock: VClock::new(),
-        };
-        instance.counter.inc_refills(node_id, max_calls as u64);
-        instance
+        }
     }
 
     fn add_tokens_to_bucket(
@@ -356,8 +370,10 @@ impl Bucket for DistributedBucket {
     }
 
     fn tokens_to_u32(&self) -> u32 {
-        self.counter
-            .tokens()
+        // Add max_calls as a local constant offset. The CRDT only tracks
+        // *changes* (periodic refills and consumption); the initial capacity is
+        // not gossiped and never lives in PNCounter state.
+        (self.counter.tokens() + BigInt::from(self.max_calls))
             .clamp(BigInt::from(0), BigInt::from(u32::MAX))
             .to_u32()
             .unwrap_or(0)
@@ -487,7 +503,12 @@ impl DistributedBucketLimiter {
                     b.mark_gossiped();
                     b
                 },
-                || ext.bucket(local_node_id),
+                || {
+                    ext.bucket(
+                        local_node_id,
+                        self.rate_limit_settings.rate_limit_max_calls_allowed,
+                    )
+                },
             );
         }
 
@@ -536,7 +557,12 @@ impl DistributedBucketLimiter {
                     existing_counter.last_gossiped_vclock = existing_counter.counter.vclock.clone();
                     existing_counter
                 },
-                || incoming_bucket.bucket(local_node_id),
+                || {
+                    incoming_bucket.bucket(
+                        local_node_id,
+                        self.rate_limit_settings.rate_limit_max_calls_allowed,
+                    )
+                },
             );
         }
     }
@@ -635,16 +661,16 @@ mod tests {
         // Start with 1 token - should be allowed
         assert!(bucket.check_if_allowed());
 
-        // Consume the token
+        // Consume the token (seed no longer stored in CRDT; counter starts at 0)
         bucket.decrement();
-        assert_eq!(bucket.counter.tokens(), BigInt::from(0));
+        assert_eq!(bucket.counter.tokens(), BigInt::from(-1));
 
-        // Should not be allowed anymore
+        // Should not be allowed anymore (tokens_to_u32 = counter.tokens + max_calls = -1 + 1 = 0)
         assert!(!bucket.check_if_allowed());
 
         // Decrementing goes below 0 (consistent with TokenBucket behavior)
         bucket.decrement();
-        assert_eq!(bucket.counter.tokens(), BigInt::from(-1));
+        assert_eq!(bucket.counter.tokens(), BigInt::from(-2));
     }
 
     #[test]
@@ -885,7 +911,7 @@ mod tests {
         assert_eq!(external.node_id, node_id);
 
         // Convert back to internal format (as if adopted by the same node).
-        let restored_bucket = external.bucket(node_id);
+        let restored_bucket = external.bucket(node_id, 10);
         assert_eq!(restored_bucket.node_id, node_id);
         assert_eq!(restored_bucket.writer_node_id, node_id);
         assert_eq!(restored_bucket.counter.tokens(), bucket.counter.tokens());
@@ -912,7 +938,7 @@ mod tests {
         // step would copy A's `counter.node_id` into B's bucket and silently
         // route all of B's future writes into slot A of the PNCounter.
         let external = bucket_a.to_external("test_client");
-        let mut bucket_b = external.bucket(node_b);
+        let mut bucket_b = external.bucket(node_b, 100);
 
         // Post-adoption invariants: origin preserved for GC, writer is local.
         assert_eq!(bucket_b.node_id, node_a, "origin must be preserved");
@@ -1103,5 +1129,67 @@ mod tests {
         let bob_a = limiter_a.check_calls_remaining_for_client(&"bob".to_string());
         let bob_b = limiter_b.check_calls_remaining_for_client(&"bob".to_string());
         assert_eq!(bob_a, bob_b, "bob's quota must match after anti-entropy");
+    }
+
+    /// Regression test: seed tokens must NOT be stored in the CRDT.
+    ///
+    /// Before the fix, `DistributedBucket::new` called `inc_refills(node_id, max_calls)`
+    /// which wrote the initial capacity into the PNCounter. Those writes propagated
+    /// via gossip and were never tracked in the ageing vec, so they could never
+    /// be expired — immortal "ghost" tokens that accumulated with every new peer
+    /// that adopted the bucket and then re-wrote their own seed.
+    ///
+    /// After the fix, `max_calls` is stored as a local field and added as a
+    /// constant offset in `tokens_to_u32()`. The CRDT state for a freshly
+    /// created bucket must be zero.
+    #[test]
+    fn test_seed_tokens_not_in_crdt() {
+        let node_id = node_id();
+
+        // A new bucket must have an empty CRDT (tokens == 0 in the counter).
+        let bucket = DistributedBucket::new(100, node_id);
+        assert_eq!(
+            bucket.counter.tokens(),
+            BigInt::from(0),
+            "CRDT counter must start empty; seed tokens must not be written into the CRDT"
+        );
+
+        // The visible quota must still equal max_calls via the constant offset.
+        assert_eq!(
+            bucket.tokens_to_u32(),
+            100,
+            "tokens_to_u32 must return max_calls for a fresh bucket"
+        );
+
+        // When this bucket is serialised and adopted by a peer, the peer's copy
+        // must also show zero tokens in the CRDT — no seed doubles on adoption.
+        let node_b = NodeName::from("b").node_id();
+        let external = bucket.to_external("client_a");
+        let adopted = external.bucket(node_b, 100);
+        assert_eq!(
+            adopted.counter.tokens(),
+            BigInt::from(0),
+            "adopted bucket must not gain extra CRDT tokens; seed doubling regression"
+        );
+
+        // Verify two-node convergence: after one request each the quota seen by
+        // both replicas must be max_calls - 2, regardless of which node adopted
+        // whose bucket.
+        let mut bucket_a = DistributedBucket::new(100, node_id);
+        bucket_a.decrement(); // A: 1 request
+
+        let external_a = bucket_a.to_external("client_a");
+        let mut bucket_b = external_a.bucket(node_b, 100);
+        bucket_b.decrement(); // B: 1 additional request
+
+        // Merge B → A
+        let external_b = bucket_b.to_external("client_a");
+        bucket_a.counter.merge(external_b.counter);
+
+        assert_eq!(
+            bucket_a.tokens_to_u32(),
+            98,
+            "after 2 total requests quota must be 98 (100 - 2), not 198"
+        );
     }
 }

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -1257,17 +1257,11 @@ mod tests {
         let c_vc = limiter_c.get_latest_updated_vclock();
 
         assert!(
-            !matches!(
-                summary.partial_cmp(&b_vc),
-                None
-            ),
+            !matches!(summary.partial_cmp(&b_vc), None),
             "summary must not be concurrent with node_b's vclock after convergence"
         );
         assert!(
-            !matches!(
-                summary.partial_cmp(&c_vc),
-                None
-            ),
+            !matches!(summary.partial_cmp(&c_vc), None),
             "summary must not be concurrent with node_c's vclock after convergence"
         );
     }

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -190,7 +190,11 @@ impl DistributedBucketExternal {
             counter: self.counter.clone(),
             requests: Vec::new(),
             last_call: Utc::now().timestamp_millis(),
-            last_gossiped_vclock: VClock::new(),
+            // Initialise the watermark to the incoming state rather than VClock::new().
+            // A freshly-adopted bucket has nothing local to re-broadcast: the
+            // original sender already gossiped it. Only local writes that arrive
+            //  *after* adoption should trigger a push.
+            last_gossiped_vclock: self.counter.vclock.clone(),
         }
     }
 }
@@ -524,6 +528,12 @@ impl DistributedBucketLimiter {
                     existing_counter
                         .counter
                         .merge(incoming_bucket.counter.clone());
+                    // Advance the watermark to the post-merge vclock so this node DOES NOT
+                    // re-broadcast state it just received from a peer.
+                    // Only local writes that happen *after* this merge will advance
+                    // counter.vclock past last_gossiped_vclock and trigger
+                    // the next delta push.
+                    existing_counter.last_gossiped_vclock = existing_counter.counter.vclock.clone();
                     existing_counter
                 },
                 || incoming_bucket.bucket(local_node_id),
@@ -947,6 +957,77 @@ mod tests {
         );
     }
 
+    /// Regression test for gossip merge cascades: accepting gossip from a peer must NOT cause
+    /// the receiver to re-broadcast that same state in the next gossip tick.
+    ///
+    /// Before the fix, `accept_delta_state` never advanced `last_gossiped_vclock`,
+    /// so every merge left `counter.vclock > last_gossiped_vclock`, which made
+    /// `has_updates_since_last_gossip` return true for every merged bucket,
+    /// triggering a re-broadcast cascade each tick.
+    #[test]
+    fn test_accepted_delta_does_not_cause_rebroadcast() {
+        let node_a = node_id();
+        let node_b = NodeName::from("b").node_id();
+        let settings = test_settings();
+
+        let mut limiter_a = DistributedBucketLimiter::new(node_a, settings.clone());
+        let mut limiter_b = DistributedBucketLimiter::new(node_b, settings);
+
+        // Node A processes a request so it has a delta to gossip.
+        limiter_a.limit_calls_for_client("client_1".to_string());
+
+        // Node B accepts A's delta.
+        let delta_from_a = limiter_a.gossip_delta_state();
+        assert!(!delta_from_a.is_empty(), "A should have a delta");
+        limiter_b.accept_delta_state(&delta_from_a);
+
+        // B has no local writes — it must produce an empty delta next tick.
+        // Before the fix, merging A's state advanced counter.vclock past B's
+        // (empty) last_gossiped_vclock, so B would re-broadcast A's data here.
+        let delta_from_b = limiter_b.gossip_delta_state();
+        assert!(
+            delta_from_b.is_empty(),
+            "receiver must not re-broadcast state it just accepted; \
+             got {} bucket(s) — gossip merge cascades regression",
+            delta_from_b.len()
+        );
+
+        // After a local write on B, B should produce a delta (its own write only).
+        limiter_b.limit_calls_for_client("client_1".to_string());
+        let delta_from_b_after_write = limiter_b.gossip_delta_state();
+        assert!(
+            !delta_from_b_after_write.is_empty(),
+            "B must gossip after a local write"
+        );
+
+        // --- Merge path (bucket already exists in the receiver) ---
+        //
+        // The insert-when-absent case above is handled by `bucket()` setting
+        // last_gossiped_vclock to the incoming vclock. The merge case (bucket
+        // already present) is a separate code path in update_or_insert_with and
+        // requires the accept_delta_state fix to advance the watermark after merge.
+
+        // Drain B's watermark so it's current again.
+        let _ = limiter_b.gossip_delta_state();
+
+        // A makes another request; B already has client_1 so the next accept will
+        // take the UPDATE (merge) path, not the INSERT path.
+        limiter_a.limit_calls_for_client("client_1".to_string());
+        let delta_from_a_2 = limiter_a.gossip_delta_state();
+        assert!(!delta_from_a_2.is_empty(), "A should have a second delta");
+        limiter_b.accept_delta_state(&delta_from_a_2);
+
+        // B again has no local writes — delta must be empty even though the merge
+        // updated an existing bucket (the merge path of update_or_insert_with).
+        let delta_from_b_after_merge = limiter_b.gossip_delta_state();
+        assert!(
+            delta_from_b_after_merge.is_empty(),
+            "receiver must not re-broadcast after merging into an existing bucket; \
+             got {} bucket(s) — S5/S6 merge-path regression",
+            delta_from_b_after_merge.len()
+        );
+    }
+
     /// `full_state_dump` must return all buckets regardless of whether they have
     /// been gossiped since their last update, unlike `gossip_delta_state` which
     /// skips watermark-current buckets.
@@ -1014,7 +1095,10 @@ mod tests {
         // After recovery B should see both clients with the same token counts as A.
         let alice_a = limiter_a.check_calls_remaining_for_client(&"alice".to_string());
         let alice_b = limiter_b.check_calls_remaining_for_client(&"alice".to_string());
-        assert_eq!(alice_a, alice_b, "alice's quota must match after anti-entropy");
+        assert_eq!(
+            alice_a, alice_b,
+            "alice's quota must match after anti-entropy"
+        );
 
         let bob_a = limiter_a.check_calls_remaining_for_client(&"bob".to_string());
         let bob_b = limiter_b.check_calls_remaining_for_client(&"bob".to_string());

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -595,6 +595,32 @@ impl DistributedBucketLimiter {
         }
     }
 
+    /// Age out expired operations on every live bucket.
+    ///
+    /// Addresses the Case where origin alive but idle: without traffic on a given
+    /// bucket, `add_tokens_to_bucket` is never called, so `expire_entries` is
+    /// never driven and the CRDT counter keeps the un-aged fill/request ops
+    /// forever. Calling this on every gossip tick ensures expirations happen
+    /// even for quiescent buckets.
+    ///
+    /// Preserves the single-writer-per-actor invariant: `expire_entries`
+    /// only writes to `self.writer_node_id`, which is always the local node's
+    /// slot, never a remote origin's. Case B (origin dead with un-aged ops at
+    /// remote replicas) is not addressed here; see the review doc.
+    pub fn tick_expirations(&self) {
+        let expiration_threshold_ms =
+            (self.rate_limit_settings.rate_limit_interval_seconds * 1000 + 1) as i64;
+        let guard = self.node_counters.pin();
+        let keys: Vec<String> = guard.iter().map(|(k, _)| k.clone()).collect();
+        for key in keys {
+            guard.update(key, |b| {
+                let mut b = b.clone();
+                b.expire_entries(expiration_threshold_ms);
+                b
+            });
+        }
+    }
+
     /// Return the join (element-wise maximum) of every bucket's vclock.
     ///
     /// This is the correct summary of "all state this node has seen": a single
@@ -863,7 +889,65 @@ mod tests {
         // Should not expire either bucket (both are recent)
         limiter.expire_keys();
         assert_eq!(limiter.len(), 2);
-    } // === CRDT Properties Tests ===
+    }
+
+    #[test]
+    fn test_tick_expirations_ages_idle_buckets() {
+        // Regression: an idle bucket's ops must age out via the
+        // periodic tick alone — `add_tokens_to_bucket` is never called on a
+        // bucket that has no new traffic, so without a background tick the
+        // un-aged entries sit in the CRDT forever.
+        let node_id = node_id();
+        let settings = settings::RateLimitSettings {
+            rate_limit_max_calls_allowed: 10,
+            rate_limit_interval_seconds: 1,
+        };
+        let limiter = DistributedBucketLimiter::new(node_id, settings);
+        let client_id = "idle_client".to_string();
+
+        // Stage a bucket that already has a stale op whose timestamp predates
+        // the expiration threshold. This avoids a 1+ second sleep in the test.
+        let threshold_ms: i64 = 1001;
+        {
+            let guard = limiter.node_counters.pin();
+            let mut bucket = DistributedBucket::new(10, node_id);
+            bucket.counter.inc_request(node_id);
+            bucket.requests.push(InternalRequestEntry {
+                op: InternalPnCounterOp::Requests(1),
+                timestamp_ms: monotonic_ms() - threshold_ms - 500,
+                vclock: bucket.vclock(),
+            });
+            guard.insert(client_id.clone(), bucket);
+        }
+
+        // Sanity: the staged decrement is visible before the tick.
+        {
+            let guard = limiter.node_counters.pin();
+            let bucket = guard.get(&client_id).unwrap();
+            assert_eq!(bucket.counter.tokens(), BigInt::from(-1));
+            assert_eq!(bucket.requests.len(), 1);
+        }
+
+        // No user traffic on this client — just a background tick.
+        limiter.tick_expirations();
+
+        // The stale op should be gone from the ageing log and the CRDT should
+        // have been compensated back to zero via the local writer slot.
+        let guard = limiter.node_counters.pin();
+        let bucket = guard.get(&client_id).unwrap();
+        assert_eq!(
+            bucket.requests.len(),
+            0,
+            "tick_expirations should have removed the expired entry"
+        );
+        assert_eq!(
+            bucket.counter.tokens(),
+            BigInt::from(0),
+            "tick_expirations should have compensated the CRDT counter"
+        );
+    }
+
+    // === CRDT Properties Tests ===
 
     #[test]
     fn test_crdt_properties() {

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -717,7 +717,7 @@ mod tests {
         let node_id = node_id();
         let mut bucket = DistributedBucket::new(1, node_id);
 
-        // Start with 1 token - should be allowed
+        // Start with 1 token should be allowed
         assert!(bucket.check_if_allowed());
 
         // Consume the token (seed no longer stored in CRDT; counter starts at 0)
@@ -992,7 +992,7 @@ mod tests {
         limiter2.limit_calls_for_client(client_id.clone());
         limiter3.limit_calls_for_client(client_id.clone());
 
-        // Full mesh gossip - each node receives updates from all others
+        // Full mesh gossip where each node receives updates from all others
         let gossip1 = limiter1.gossip_delta_state();
         let gossip2 = limiter2.gossip_delta_state();
         let gossip3 = limiter3.gossip_delta_state();
@@ -1315,8 +1315,8 @@ mod tests {
     ///
     /// When multiple clients have buckets written by *different* nodes, their vclocks
     /// are concurrent (each has dots the other lacks). The old implementation used
-    /// `acc > bucket.vclock()` to fold, which — because `>` is false for concurrent
-    /// vclocks — dropped earlier actors on every step, producing a result that varied
+    /// `acc > bucket.vclock()` to fold, and because `>` is false for concurrent
+    /// vclocks it dropped earlier actors on every step, producing a result that varied
     /// with HashMap iteration order. This made heartbeat comparisons spuriously
     /// `None` (concurrent) and triggered permanent anti-entropy `StateRequest` loops.
     ///
@@ -1376,5 +1376,191 @@ mod tests {
             !matches!(summary.partial_cmp(&c_vc), None),
             "summary must not be concurrent with node_c's vclock after convergence"
         );
+    }
+
+    /// ===== Property tests for CRDT convergence under arbitrary interleaving =====
+    ///
+    /// The unit tests above each exercise one or two concrete op sequences, but
+    /// the `DistributedBucket` layer adds ageing, seed-token removal, and
+    /// writer-vs-origin identity that the upstream `crdts` crate tests do not
+    /// cover. Generating random op sequences and asserting the CRDT laws hold at
+    /// the `DistributedBucketLimiter` level gives us broad, adversarial coverage.
+    ///
+    /// Three properties are tested:
+    ///   1. Convergence — full-mesh gossip terminates in agreement.
+    ///   2. Idempotency — applying the same delta twice == applying it once.
+    ///   3. Commutativity — the merge order of two independent deltas does not
+    ///      matter.
+    mod prop_tests {
+        use super::*;
+        use proptest::prelude::*;
+
+        const CLIENTS: &[&str] = &["alice", "bob", "carol"];
+        const NUM_NODES: usize = 3;
+
+        fn prop_node_ids() -> Vec<NodeId> {
+            (0..NUM_NODES)
+                .map(|i| NodeName::from(format!("node-{i}").as_str()).node_id())
+                .collect()
+        }
+
+        /// Long interval so no entries expire during a fast property-test run.
+        /// `expire_entries` threshold = interval_seconds * 1000 + 1 ms.
+        /// At 60 s that is 60 001 ms, well above the process-local monotonic
+        /// clock value for any test that runs in under a minute.
+        fn long_interval_settings() -> settings::RateLimitSettings {
+            settings::RateLimitSettings {
+                rate_limit_max_calls_allowed: 100,
+                rate_limit_interval_seconds: 60,
+            }
+        }
+
+        // After any sequence of rate-limit ops distributed across N nodes,
+        // a single full-mesh gossip round must bring every node to identical
+        // `check_calls_remaining_for_client` values for every client that
+        // received at least one op.
+        //
+        // This is the primary regression test for S1-style violations: if
+        // writes land in the wrong actor slot they get silently discarded on
+        // merge and the nodes diverge.
+        proptest! {
+            #[test]
+            fn prop_full_mesh_gossip_converges(
+                ops in proptest::collection::vec(
+                    (0usize..NUM_NODES, 0usize..CLIENTS.len()),
+                    1..30usize,
+                )
+            ) {
+                let settings = long_interval_settings();
+                let ids = prop_node_ids();
+
+                let mut limiters: Vec<DistributedBucketLimiter> = ids
+                    .iter()
+                    .map(|&id| DistributedBucketLimiter::new(id, settings.clone()))
+                    .collect();
+
+                for &(node_idx, client_idx) in &ops {
+                    limiters[node_idx].limit_calls_for_client(CLIENTS[client_idx].to_string());
+                }
+
+                // Full-mesh gossip: each node pushes its current delta to every
+                // other node. Collect all deltas before applying any so that the
+                // merge order within a round does not affect the outcome.
+                let deltas: Vec<Vec<DistributedBucketExternal>> = limiters
+                    .iter()
+                    .map(|l| l.gossip_delta_state())
+                    .collect();
+                for (i, delta) in deltas.iter().enumerate() {
+                    if !delta.is_empty() {
+                        for j in 0..NUM_NODES {
+                            if i != j {
+                                limiters[j].accept_delta_state(delta);
+                            }
+                        }
+                    }
+                }
+
+                // Assert convergence for every client that saw at least one op.
+                for &(_, ci) in &ops {
+                    let client_str = CLIENTS[ci].to_string();
+                    let counts: Vec<u32> = limiters
+                        .iter()
+                        .map(|l| l.check_calls_remaining_for_client(&client_str))
+                        .collect();
+                    let first = counts[0];
+                    for &c in &counts[1..] {
+                        prop_assert_eq!(
+                            c, first,
+                            "convergence violated for '{}': node counts = {:?}",
+                            CLIENTS[ci], counts
+                        );
+                    }
+                }
+            }
+        }
+
+        // `accept_delta_state` must be idempotent: applying the same delta a
+        // second time must not change the merged state.
+        proptest! {
+            #[test]
+            fn prop_accept_delta_is_idempotent(
+                ops in proptest::collection::vec(0usize..CLIENTS.len(), 1..15usize)
+            ) {
+                let settings = long_interval_settings();
+                let ids = prop_node_ids();
+
+                let mut sender = DistributedBucketLimiter::new(ids[0], settings.clone());
+                let mut recv_once = DistributedBucketLimiter::new(ids[1], settings.clone());
+                let mut recv_twice = DistributedBucketLimiter::new(ids[2], settings.clone());
+
+                for &ci in &ops {
+                    sender.limit_calls_for_client(CLIENTS[ci].to_string());
+                }
+                let delta = sender.gossip_delta_state();
+
+                recv_once.accept_delta_state(&delta);
+
+                recv_twice.accept_delta_state(&delta);
+                recv_twice.accept_delta_state(&delta); // second application must be a no-op
+
+                for client in CLIENTS {
+                    let client_str = client.to_string();
+                    let once = recv_once.check_calls_remaining_for_client(&client_str);
+                    let twice = recv_twice.check_calls_remaining_for_client(&client_str);
+                    prop_assert_eq!(
+                        once, twice,
+                        "idempotency violated for '{}': once={}, twice={}",
+                        client_str, once, twice
+                    );
+                }
+            }
+        }
+
+        // Merging deltas from two independent nodes must be commutative: the
+        // token count after (A then B) must equal the count after (B then A).
+        proptest! {
+            #[test]
+            fn prop_accept_delta_is_commutative(
+                ops_a in proptest::collection::vec(0usize..CLIENTS.len(), 1..15usize),
+                ops_b in proptest::collection::vec(0usize..CLIENTS.len(), 1..15usize),
+            ) {
+                let settings = long_interval_settings();
+                let ids = prop_node_ids();
+
+                let mut limiter_a = DistributedBucketLimiter::new(ids[0], settings.clone());
+                let mut limiter_b = DistributedBucketLimiter::new(ids[1], settings.clone());
+
+                for &ci in &ops_a {
+                    limiter_a.limit_calls_for_client(CLIENTS[ci].to_string());
+                }
+                for &ci in &ops_b {
+                    limiter_b.limit_calls_for_client(CLIENTS[ci].to_string());
+                }
+
+                let delta_a = limiter_a.gossip_delta_state();
+                let delta_b = limiter_b.gossip_delta_state();
+
+                // r_ab: merge A first, then B
+                let mut r_ab = DistributedBucketLimiter::new(ids[2], settings.clone());
+                r_ab.accept_delta_state(&delta_a);
+                r_ab.accept_delta_state(&delta_b);
+
+                // r_ba: merge B first, then A
+                let mut r_ba = DistributedBucketLimiter::new(ids[2], settings.clone());
+                r_ba.accept_delta_state(&delta_b);
+                r_ba.accept_delta_state(&delta_a);
+
+                for client in CLIENTS {
+                    let client_str = client.to_string();
+                    let ab = r_ab.check_calls_remaining_for_client(&client_str);
+                    let ba = r_ba.check_calls_remaining_for_client(&client_str);
+                    prop_assert_eq!(
+                        ab, ba,
+                        "commutativity violated for '{}': A∘B={}, B∘A={}",
+                        client_str, ab, ba
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/limiters/distributed_bucket.rs
+++ b/src/limiters/distributed_bucket.rs
@@ -567,16 +567,21 @@ impl DistributedBucketLimiter {
         }
     }
 
+    /// Return the join (element-wise maximum) of every bucket's vclock.
+    ///
+    /// This is the correct summary of "all state this node has seen": a single
+    /// vclock whose value at each actor slot is the highest dot observed across
+    /// any bucket. Using `>` (strict dominance) instead of merge would silently
+    /// drop dots from concurrent vclocks whose iteration order is non-deterministic,
+    /// causing heartbeat comparisons to be spuriously `None` (concurrent) and
+    /// triggering permanent anti-entropy state requests.
     pub fn get_latest_updated_vclock(&self) -> VClock<NodeId> {
         self.node_counters
             .pin()
             .values()
-            .fold(VClock::new(), |acc, bucket| {
-                if acc > bucket.vclock() {
-                    acc
-                } else {
-                    bucket.vclock()
-                }
+            .fold(VClock::new(), |mut acc, bucket| {
+                acc.merge(bucket.vclock());
+                acc
             })
     }
 
@@ -1190,6 +1195,80 @@ mod tests {
             bucket_a.tokens_to_u32(),
             98,
             "after 2 total requests quota must be 98 (100 - 2), not 198"
+        );
+    }
+
+    /// Regression test for `get_latest_updated_vclock` returning the join of all
+    /// bucket vclocks rather than the max of any single bucket vclock.
+    ///
+    /// When multiple clients have buckets written by *different* nodes, their vclocks
+    /// are concurrent (each has dots the other lacks). The old implementation used
+    /// `acc > bucket.vclock()` to fold, which — because `>` is false for concurrent
+    /// vclocks — dropped earlier actors on every step, producing a result that varied
+    /// with HashMap iteration order. This made heartbeat comparisons spuriously
+    /// `None` (concurrent) and triggered permanent anti-entropy `StateRequest` loops.
+    ///
+    /// The fix uses `acc.merge(vclock)` to compute the element-wise maximum (join),
+    /// which always produces a stable vclock that covers every known actor slot.
+    #[test]
+    fn test_get_latest_updated_vclock_is_join_of_all_buckets() {
+        let node_a = node_id();
+        let node_b = NodeName::from("b").node_id();
+        let node_c = NodeName::from("c").node_id();
+        let settings = test_settings();
+
+        let mut limiter = DistributedBucketLimiter::new(node_a, settings.clone());
+
+        // Each client is processed by a different writer node, so their bucket
+        // vclocks are concurrent (disjoint actor sets).
+        let mut limiter_b = DistributedBucketLimiter::new(node_b, settings.clone());
+        let mut limiter_c = DistributedBucketLimiter::new(node_c, settings);
+
+        limiter.limit_calls_for_client("client_a".to_string()); // vclock {node_a: n}
+        limiter_b.limit_calls_for_client("client_b".to_string()); // vclock {node_b: n}
+        limiter_c.limit_calls_for_client("client_c".to_string()); // vclock {node_c: n}
+
+        // Converge all state into `limiter`.
+        limiter.accept_delta_state(&limiter_b.gossip_delta_state());
+        limiter.accept_delta_state(&limiter_c.gossip_delta_state());
+
+        // The summary vclock must cover all three actor slots.
+        let summary = limiter.get_latest_updated_vclock();
+
+        // The summary must dominate each individual bucket vclock.
+        for ext in limiter.full_state_dump() {
+            let bucket_vc = ext.counter.vclock;
+            assert!(
+                matches!(
+                    summary.partial_cmp(&bucket_vc),
+                    Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
+                ),
+                "summary vclock must dominate every bucket vclock; \
+                 summary={:?} did not dominate bucket={:?}",
+                summary,
+                bucket_vc
+            );
+        }
+
+        // Specifically: the summary must not be concurrent with any peer's
+        // individual bucket vclock. If it were, heartbeat comparisons would
+        // produce None and trigger spurious StateRequests.
+        let b_vc = limiter_b.get_latest_updated_vclock();
+        let c_vc = limiter_c.get_latest_updated_vclock();
+
+        assert!(
+            !matches!(
+                summary.partial_cmp(&b_vc),
+                None
+            ),
+            "summary must not be concurrent with node_b's vclock after convergence"
+        );
+        assert!(
+            !matches!(
+                summary.partial_cmp(&c_vc),
+                None
+            ),
+            "summary must not be concurrent with node_c's vclock after convergence"
         );
     }
 }

--- a/src/limiters/token_bucket.rs
+++ b/src/limiters/token_bucket.rs
@@ -161,18 +161,18 @@ impl TokenBucketLimiter {
             updated_bucket.add_tokens_to_bucket(&self.settings);
 
             if updated_bucket.check_if_allowed() {
-                // Call is allowed - decrement and update
+                // Call is allowed! Decrement and update
                 updated_bucket.decrement();
                 let remaining = updated_bucket.tokens_to_u32();
                 self.cache.pin().insert(key, updated_bucket);
                 Some(remaining)
             } else {
-                // Call not allowed - update bucket state but don't decrement
+                // Call not allowed! Update bucket state but don't decrement
                 self.cache.pin().insert(key, updated_bucket);
                 None
             }
         } else {
-            // Create new bucket - first call is always allowed
+            // Create new bucket. First call is always allowed
             let mut new_bucket = self.new_bucket();
             new_bucket.decrement(); // Use one token
                                     // if negative here, we'll have an unreliable value.
@@ -605,7 +605,7 @@ mod tests {
             .is_some());
         assert_eq!(limiter.check_calls_remaining_for_client("clientB"), 4);
 
-        // Client C makes no requests - should have full quota
+        // Client C makes no requests and should have full quota
         assert_eq!(limiter.check_calls_remaining_for_client("clientC"), 5);
 
         // Client A should still have 2 remaining

--- a/src/limiters/token_bucket.rs
+++ b/src/limiters/token_bucket.rs
@@ -58,11 +58,10 @@ impl Bucket for TokenBucket {
         let diff_ms: i64 = Utc::now().timestamp_millis() - self.last_call;
         // For this algorithm we arbitrarily do not trust intervals less than 5ms,
         // so we only *add* tokens if the diff is greater than that.
-        let diff_ms: i32 = diff_ms as i32;
-        if diff_ms < 5i32 {
+        if diff_ms < 5i64 {
             return self;
         }
-        let tokens_to_add: f64 = rate_limit_settings.token_rate_milliseconds() * f64::from(diff_ms);
+        let tokens_to_add: f64 = rate_limit_settings.token_rate_milliseconds() * (diff_ms as f64);
         self.tokens = (self.tokens + tokens_to_add).clamp(
             0.0,
             f64::from(rate_limit_settings.rate_limit_max_calls_allowed),

--- a/src/node/gossip/controller.rs
+++ b/src/node/gossip/controller.rs
@@ -583,6 +583,9 @@ impl GossipController {
     }
 
     pub async fn handle_gossip_tick(&self) -> Result<()> {
+        // Fix origin alive but idle: age out expired ops on idle buckets before collecting
+        // deltas, so any resulting decrements ride this same gossip round.
+        self.tick_all_expirations()?;
         // Send delta updates for buckets that have changed
         let updates = self.collect_gossip_updates().await?;
         if !updates.is_empty() {
@@ -627,6 +630,25 @@ impl GossipController {
         Ok(())
     }
 
+    /// Drive ageing on every known limiter's live buckets.
+    ///
+    /// Without this, an idle bucket's ops never age out: `expire_entries` is
+    /// otherwise only called transitively from `add_tokens_to_bucket`, which
+    /// only runs when the bucket receives a new request. Called on each gossip
+    /// tick so that un-aged ops are expired locally and the resulting CRDT
+    /// decrements are picked up by the very next `collect_gossip_updates`.
+    pub fn tick_all_expirations(&self) -> Result<()> {
+        let limiters: Vec<Arc<Mutex<DistributedBucketLimiter>>> =
+            self.named_rate_limiters.pin().values().cloned().collect();
+        for limiter_arc in limiters {
+            let limiter = limiter_arc
+                .lock()
+                .map_err(|e| ColibriError::Concurrency(format!("Lock poisoned: {}", e)))?;
+            limiter.tick_expirations();
+        }
+        Ok(())
+    }
+
     /// Collect buckets that have been updated and should be gossiped
     pub async fn collect_gossip_updates(&self) -> Result<Vec<DistributedBucketExternal>> {
         let limiter_arc = self.get_limiter(None)?;
@@ -650,7 +672,10 @@ impl GossipController {
                     })?;
                     let (ref mut seen, ref mut order) = *cache;
                     if seen.contains(&packet.packet_id) {
-                        debug!("[{}] Dropping duplicate packet {}", self.node_id, packet.packet_id);
+                        debug!(
+                            "[{}] Dropping duplicate packet {}",
+                            self.node_id, packet.packet_id
+                        );
                         return Ok(());
                     }
                     seen.insert(packet.packet_id);

--- a/src/node/gossip/controller.rs
+++ b/src/node/gossip/controller.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
@@ -20,6 +21,10 @@ use crate::settings::{self, ClusterTopology, RateLimitSettings, RunMode};
 use crate::transport::{UdpReceiver, UdpTransport};
 
 use super::{GossipMessage, GossipPacket};
+
+/// Maximum number of recent packet IDs kept for receive-side deduplication.
+/// At ~50 gossip packets/sec in a small cluster, this is a ~20-second window.
+const DEDUP_CACHE_SIZE: usize = 1000;
 
 type GossipReceiveChannel = Arc<Mutex<Option<mpsc::Receiver<(Bytes, SocketAddr)>>>>;
 
@@ -46,6 +51,10 @@ pub struct GossipController {
     msg_receive_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     /// Handle for the message evaluation loop (reads from channel, calls process_gossip_packet)
     pub msg_eval_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    /// Receive-side deduplication cache. Stores recently seen packet_ids so that
+    /// re-propagated or retransmitted packets are dropped without reprocessing.
+    /// Bounded to DEDUP_CACHE_SIZE entries; oldest entries are evicted in FIFO order.
+    seen_packet_ids: Arc<Mutex<(HashSet<u64>, VecDeque<u64>)>>,
 }
 
 impl std::fmt::Debug for GossipController {
@@ -105,6 +114,7 @@ impl GossipController {
             receive_chan: Arc::new(Mutex::new(Some(receive_chan))),
             msg_receive_handle: Arc::new(Mutex::new(None)),
             msg_eval_handle: Arc::new(Mutex::new(None)),
+            seen_packet_ids: Arc::new(Mutex::new((HashSet::new(), VecDeque::new()))),
         })
     }
 
@@ -628,8 +638,30 @@ impl GossipController {
 
     /// Process an incoming gossip packet
     pub async fn process_gossip_packet(&self, data: Bytes, peer_addr: SocketAddr) -> Result<()> {
-        match GossipPacket::deserialize(&data) {
+        match GossipPacket::from_wire(&data) {
             Ok(packet) => {
+                // Dedup: drop packets whose id we've already processed.
+                // This prevents re-propagated or retransmitted packets from
+                // being applied twice. The seen-set is bounded to DEDUP_CACHE_SIZE;
+                // oldest entries are evicted in FIFO order.
+                {
+                    let mut cache = self.seen_packet_ids.lock().map_err(|e| {
+                        ColibriError::Concurrency(format!("seen_packet_ids poisoned: {}", e))
+                    })?;
+                    let (ref mut seen, ref mut order) = *cache;
+                    if seen.contains(&packet.packet_id) {
+                        debug!("[{}] Dropping duplicate packet {}", self.node_id, packet.packet_id);
+                        return Ok(());
+                    }
+                    seen.insert(packet.packet_id);
+                    order.push_back(packet.packet_id);
+                    if order.len() > DEDUP_CACHE_SIZE {
+                        if let Some(old_id) = order.pop_front() {
+                            seen.remove(&old_id);
+                        }
+                    }
+                }
+
                 match packet.message {
                     GossipMessage::StateRequest {
                         requesting_node_id,
@@ -901,14 +933,21 @@ impl GossipController {
                 Ok(())
             }
             Err(e) => {
-                debug!(
-                    "[{}] Failed to deserialize packet: {} from {}",
-                    self.node_id, e, peer_addr
-                );
-                Err(ColibriError::Transport(format!(
-                    "Deserialization failed: {}",
-                    e
-                )))
+                // Version mismatches are a deployment signal (mixed-version
+                // cluster); log at warn so they're visible without being noisy.
+                // Pure decode errors are debug-level (malformed/truncated UDP).
+                use super::messages::GossipDecodeError;
+                match &e {
+                    GossipDecodeError::VersionMismatch { expected, got } => warn!(
+                        "[{}] Gossip protocol version mismatch from {}: expected {}, got {}",
+                        self.node_id, peer_addr, expected, got
+                    ),
+                    GossipDecodeError::Decode(_) => debug!(
+                        "[{}] Failed to decode gossip packet from {}: {}",
+                        self.node_id, peer_addr, e
+                    ),
+                }
+                Err(ColibriError::Transport(format!("{}", e)))
             }
         }
     }

--- a/src/node/gossip/controller.rs
+++ b/src/node/gossip/controller.rs
@@ -655,14 +655,14 @@ impl GossipController {
                         };
 
                         if !state.is_empty() {
-                            // Respond with a DeltaStateSync (propagation_factor 0 so the
+                            // Respond with a DeltaStateSync (propagation_factor 1 so the
                             // anti-entropy response is not re-gossiped further). The receiver
                             // already handles DeltaStateSync idempotently via CRDT merge.
                             let response = GossipMessage::DeltaStateSync {
                                 updates: state,
                                 sender_node_id: self.node_id,
                                 response_addr: self.response_addr,
-                                propagation_factor: 0,
+                                propagation_factor: 1,
                             };
                             let packet = GossipPacket::new(response);
                             if let Err(e) = self.send_gossip_packet_to(requester_addr, packet).await

--- a/src/node/gossip/controller.rs
+++ b/src/node/gossip/controller.rs
@@ -500,7 +500,10 @@ impl GossipController {
         let limiter = limiter_arc
             .lock()
             .map_err(|e| ColibriError::Concurrency(format!("Lock poisoned: {}", e)))?;
-        debug!("[{}] State request - returning full state dump", self.node_id);
+        debug!(
+            "[{}] State request - returning full state dump",
+            self.node_id
+        );
         Ok(limiter.full_state_dump())
     }
 
@@ -510,14 +513,11 @@ impl GossipController {
     /// a single address — used for anti-entropy responses where we know exactly
     /// who to reply to.
     async fn send_gossip_packet_to(&self, addr: SocketAddr, packet: GossipPacket) -> Result<()> {
-        let data = packet.serialize().map_err(|e| {
-            ColibriError::Transport(format!("Serialization failed: {}", e))
-        })?;
+        let data = packet
+            .serialize()
+            .map_err(|e| ColibriError::Transport(format!("Serialization failed: {}", e)))?;
         self.transport.send_to_peer(addr, &data).await?;
-        debug!(
-            "[{}] Sent targeted gossip packet to {}",
-            self.node_id, addr
-        );
+        debug!("[{}] Sent targeted gossip packet to {}", self.node_id, addr);
         Ok(())
     }
 
@@ -665,8 +665,7 @@ impl GossipController {
                                 propagation_factor: 0,
                             };
                             let packet = GossipPacket::new(response);
-                            if let Err(e) =
-                                self.send_gossip_packet_to(requester_addr, packet).await
+                            if let Err(e) = self.send_gossip_packet_to(requester_addr, packet).await
                             {
                                 warn!(
                                     "[{}] Failed to send anti-entropy response to {}: {}",

--- a/src/node/gossip/controller.rs
+++ b/src/node/gossip/controller.rs
@@ -487,29 +487,38 @@ impl GossipController {
         Ok(())
     }
 
-    /// Gossip-specific: Handle state request
+    /// Gossip-specific: Handle state request (HTTP path).
+    ///
+    /// Returns the full state dump for anti-entropy. We always dump everything
+    /// regardless of which keys were requested — state-based CRDT merge is
+    /// idempotent so extra data is harmless, and simplicity beats precision here.
     async fn handle_state_request(
         &self,
-        missing_keys: Option<Vec<String>>,
+        _missing_keys: Option<Vec<String>>,
     ) -> Result<Vec<DistributedBucketExternal>> {
         let limiter_arc = self.get_limiter(None)?;
         let limiter = limiter_arc
             .lock()
             .map_err(|e| ColibriError::Concurrency(format!("Lock poisoned: {}", e)))?;
+        debug!("[{}] State request - returning full state dump", self.node_id);
+        Ok(limiter.full_state_dump())
+    }
 
-        if let Some(_keys) = missing_keys {
-            debug!(
-                "[{}] State request with specific keys - returning all state",
-                self.node_id
-            );
-            Ok(limiter.gossip_delta_state())
-        } else {
-            debug!(
-                "[{}] State request - returning all delta state",
-                self.node_id
-            );
-            Ok(limiter.gossip_delta_state())
-        }
+    /// Send a gossip packet to a specific peer address (unicast).
+    ///
+    /// Unlike `send_gossip_packet` which fans out to random peers, this targets
+    /// a single address — used for anti-entropy responses where we know exactly
+    /// who to reply to.
+    async fn send_gossip_packet_to(&self, addr: SocketAddr, packet: GossipPacket) -> Result<()> {
+        let data = packet.serialize().map_err(|e| {
+            ColibriError::Transport(format!("Serialization failed: {}", e))
+        })?;
+        self.transport.send_to_peer(addr, &data).await?;
+        debug!(
+            "[{}] Sent targeted gossip packet to {}",
+            self.node_id, addr
+        );
+        Ok(())
     }
 
     /// Check if this node has gossip enabled
@@ -622,11 +631,54 @@ impl GossipController {
         match GossipPacket::deserialize(&data) {
             Ok(packet) => {
                 match packet.message {
-                    GossipMessage::StateRequest { .. } => {
-                        debug!(
-                            "[{}] Received StateRequest - not yet implemented",
-                            self.node_id
+                    GossipMessage::StateRequest {
+                        requesting_node_id,
+                        response_addr: requester_addr,
+                        ..
+                    } => {
+                        // Don't respond to our own requests (shouldn't happen but guard anyway)
+                        if requesting_node_id == self.node_id {
+                            return Ok(());
+                        }
+
+                        info!(
+                            "[GOSSIP_ANTI_ENTROPY] node:{} received StateRequest from:{}",
+                            self.node_id, requesting_node_id
                         );
+
+                        let state = {
+                            let limiter_arc = self.get_limiter(None)?;
+                            let limiter = limiter_arc.lock().map_err(|e| {
+                                ColibriError::Concurrency(format!("Lock poisoned: {}", e))
+                            })?;
+                            limiter.full_state_dump()
+                        };
+
+                        if !state.is_empty() {
+                            // Respond with a DeltaStateSync (propagation_factor 0 so the
+                            // anti-entropy response is not re-gossiped further). The receiver
+                            // already handles DeltaStateSync idempotently via CRDT merge.
+                            let response = GossipMessage::DeltaStateSync {
+                                updates: state,
+                                sender_node_id: self.node_id,
+                                response_addr: self.response_addr,
+                                propagation_factor: 0,
+                            };
+                            let packet = GossipPacket::new(response);
+                            if let Err(e) =
+                                self.send_gossip_packet_to(requester_addr, packet).await
+                            {
+                                warn!(
+                                    "[{}] Failed to send anti-entropy response to {}: {}",
+                                    self.node_id, requester_addr, e
+                                );
+                            }
+                        } else {
+                            debug!(
+                                "[{}] StateRequest from {} but limiter is empty — nothing to send",
+                                self.node_id, requesting_node_id
+                            );
+                        }
                     }
                     GossipMessage::DeltaStateSync {
                         updates,
@@ -679,12 +731,64 @@ impl GossipController {
                     GossipMessage::Heartbeat {
                         node_id: heartbeat_node_id,
                         timestamp: _,
-                        vclock: _,
-                        response_addr: _,
+                        vclock: peer_vclock,
+                        response_addr: peer_response_addr,
                     } => {
                         // Don't process our own heartbeat
                         if heartbeat_node_id == self.node_id {
                             return Ok(());
+                        }
+
+                        // Anti-entropy: if the peer's vclock has dots we don't have,
+                        // request their full state. The CRDT merge is idempotent so
+                        // requesting unnecessarily is safe; missing an update is not.
+                        //
+                        // `our_vclock >= peer_vclock` (causal dominance) means we have
+                        // seen every event the peer has. If that is not the case, the peer
+                        // is ahead on at least one actor slot — request a full sync.
+                        if !peer_vclock.is_empty() {
+                            let our_vclock = {
+                                let limiter_arc = self.get_limiter(None)?;
+                                let limiter = limiter_arc.lock().map_err(|e| {
+                                    ColibriError::Concurrency(format!("Lock poisoned: {}", e))
+                                })?;
+                                limiter.get_latest_updated_vclock()
+                            };
+
+                            // Request state when our clock is strictly behind the peer
+                            // (Some(Less)) OR concurrent with it (None — both nodes have
+                            // events the other hasn't seen). Both cases mean the peer has
+                            // at least one update we're missing.
+                            let peer_has_unseen_state = matches!(
+                                our_vclock.partial_cmp(&peer_vclock),
+                                Some(std::cmp::Ordering::Less) | None
+                            );
+
+                            if peer_has_unseen_state {
+                                info!(
+                                    "[GOSSIP_ANTI_ENTROPY] node:{} vclock behind peer:{}, sending StateRequest to {}",
+                                    self.node_id, heartbeat_node_id, peer_response_addr
+                                );
+                                let request = GossipMessage::StateRequest {
+                                    requesting_node_id: self.node_id,
+                                    missing_keys: None,
+                                    response_addr: self.response_addr,
+                                };
+                                let packet = GossipPacket::new(request);
+                                if let Err(e) =
+                                    self.send_gossip_packet_to(peer_response_addr, packet).await
+                                {
+                                    warn!(
+                                        "[{}] Failed to send StateRequest to {}: {}",
+                                        self.node_id, peer_response_addr, e
+                                    );
+                                }
+                            } else {
+                                debug!(
+                                    "[{}] Heartbeat from {}: vclock is current, no anti-entropy needed",
+                                    self.node_id, heartbeat_node_id
+                                );
+                            }
                         }
                     }
 

--- a/src/node/gossip/controller.rs
+++ b/src/node/gossip/controller.rs
@@ -511,7 +511,7 @@ impl GossipController {
             .lock()
             .map_err(|e| ColibriError::Concurrency(format!("Lock poisoned: {}", e)))?;
         debug!(
-            "[{}] State request - returning full state dump",
+            "[{}] State request: returning full state dump",
             self.node_id
         );
         Ok(limiter.full_state_dump())
@@ -566,7 +566,7 @@ impl GossipController {
         // We are taking a single reference to this mutex here
         loop {
             tokio::select! {
-                // Gossip timer - send delta updates
+                // Gossip timer -> send delta updates
                 _ = gossip_timer.tick() => {
                     if let Err(e) = self.handle_gossip_tick().await {
                         debug!("[{}] Error during gossip tick: {}", node_id, e);
@@ -1005,7 +1005,7 @@ impl GossipController {
         // Send to multiple random peers up to gossip_fanout
         let send_count = self.gossip_fanout.min(peers.len());
 
-        // Select random peers - must complete before any await to avoid Send issues
+        // Select random peers. (This must complete before any await to avoid Send issues)
         let selected_peers: Vec<_> = {
             use rand::prelude::IndexedRandom;
             let mut rng = rand::rng();

--- a/src/node/gossip/gossip_node.rs
+++ b/src/node/gossip/gossip_node.rs
@@ -20,7 +20,7 @@ pub struct GossipNode {
     /// Node name
     pub node_name: NodeName,
 
-    /// Controller - handles all operations via handle_message() and UDP network communication
+    /// The Controller handles all operations via handle_message() and UDP network communication
     pub controller: Arc<GossipController>,
 }
 
@@ -242,14 +242,14 @@ impl GossipNode {
             },
         };
 
-        tracing::info!("Gossip node export skipped - using gossip synchronization");
+        tracing::info!("Gossip node export skipped. Using gossip synchronization");
         Ok(export)
     }
 
     pub async fn handle_import_buckets(&self, _import_data: BucketExport) -> Result<()> {
         // Gossip nodes don't use bucket-based data import
         // Data synchronization happens through gossip protocol
-        tracing::info!("Gossip node data import skipped - using gossip synchronization");
+        tracing::info!("Gossip node data import skipped. Using gossip synchronization");
         Ok(())
     }
 
@@ -292,7 +292,7 @@ impl GossipNode {
 
 #[cfg(test)]
 mod tests {
-    //! Simple tests for GossipNode functionality - traffic direction and command forwarding
+    //! Simple tests for GossipNode functionality, including traffic direction and command forwarding
 
     use super::*;
 

--- a/src/node/gossip/messages.rs
+++ b/src/node/gossip/messages.rs
@@ -11,6 +11,43 @@ use crate::limiters::distributed_bucket::DistributedBucketExternal;
 use crate::limiters::{RuleList, RuleName, SerializableRule};
 use crate::node::NodeId;
 
+/// Wire protocol version. Bump this whenever the `GossipMessage` enum or
+/// `GossipPacket` layout changes in a backward-incompatible way.
+///
+/// Since postcard is position-dependent (enum variant discriminants are
+/// positional), removing or reordering variants silently corrupts traffic on a
+/// mixed-version cluster. Bumping this constant and rejecting mismatches on the
+/// receive side turns that silent corruption into a hard, logged error.
+pub const GOSSIP_PROTOCOL_VERSION: u16 = 1;
+
+/// Error returned by [`GossipPacket::from_wire`].
+#[derive(Debug)]
+pub enum GossipDecodeError {
+    /// Postcard deserialization failed (truncated, corrupt, or wrong format).
+    Decode(postcard::Error),
+    /// The packet's protocol version does not match [`GOSSIP_PROTOCOL_VERSION`].
+    VersionMismatch { expected: u16, got: u16 },
+}
+
+impl std::fmt::Display for GossipDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decode(e) => write!(f, "gossip decode error: {}", e),
+            Self::VersionMismatch { expected, got } => write!(
+                f,
+                "gossip protocol version mismatch: expected {}, got {}",
+                expected, got
+            ),
+        }
+    }
+}
+
+impl From<postcard::Error> for GossipDecodeError {
+    fn from(e: postcard::Error) -> Self {
+        Self::Decode(e)
+    }
+}
+
 /// Gossip message types for production delta-state protocol
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GossipMessage {
@@ -72,35 +109,59 @@ pub enum GossipMessage {
     },
 }
 
-/// GossipPacket wraps messages for network transmission
+/// GossipPacket wraps messages for network transmission.
+///
+/// Field order matters for postcard: `protocol_version` is first so that a
+/// receiver on a different version sees an immediately-wrong version number
+/// rather than silently misinterpreting the payload as a different message type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GossipPacket {
+    /// Wire protocol version. Always set to [`GOSSIP_PROTOCOL_VERSION`].
+    pub protocol_version: u16,
+    /// Random ID for receive-side deduplication.
+    pub packet_id: u64,
     pub message: GossipMessage,
-    pub packet_id: u64, // For deduplication
 }
 
 impl GossipPacket {
-    /// Create a new gossip packet
+    /// Create a new gossip packet with a random packet ID.
     pub fn new(message: GossipMessage) -> Self {
         Self {
+            protocol_version: GOSSIP_PROTOCOL_VERSION,
+            packet_id: rand::random(),
             message,
-            packet_id: rand::random(), // Generate random packet ID
         }
     }
 
-    /// Create a new gossip packet with specific ID
+    /// Create a new gossip packet with a specific ID (useful in tests).
     pub fn new_with_id(message: GossipMessage, packet_id: u64) -> Self {
-        Self { message, packet_id }
+        Self {
+            protocol_version: GOSSIP_PROTOCOL_VERSION,
+            packet_id,
+            message,
+        }
     }
 
-    /// Serialize for INTERNAL cluster communication (UDP gossip)
+    /// Serialize for INTERNAL cluster communication (UDP gossip).
     pub fn serialize(&self) -> Result<bytes::Bytes, postcard::Error> {
         to_allocvec(self).map(bytes::Bytes::from)
     }
 
-    /// Deserialize from INTERNAL cluster communication (UDP gossip)
-    pub fn deserialize(data: &[u8]) -> Result<Self, postcard::Error> {
-        from_bytes(data)
+    /// Deserialize and version-check a raw gossip packet from the wire.
+    ///
+    /// Returns `Err(GossipDecodeError::VersionMismatch)` when the packet's
+    /// `protocol_version` differs from [`GOSSIP_PROTOCOL_VERSION`]. This turns
+    /// what would otherwise be silent postcard corruption on a mixed-version
+    /// cluster into a hard, logged error.
+    pub fn from_wire(data: &[u8]) -> Result<Self, GossipDecodeError> {
+        let packet: Self = from_bytes(data)?;
+        if packet.protocol_version != GOSSIP_PROTOCOL_VERSION {
+            return Err(GossipDecodeError::VersionMismatch {
+                expected: GOSSIP_PROTOCOL_VERSION,
+                got: packet.protocol_version,
+            });
+        }
+        Ok(packet)
     }
 }
 
@@ -120,8 +181,8 @@ mod tests {
 
         // Test postcard serialization (for internal cluster communication)
         let serialized = packet.serialize().expect("Failed to serialize packet");
-        let deserialized =
-            GossipPacket::deserialize(&serialized).expect("Failed to deserialize packet");
+        let deserialized = GossipPacket::from_wire(&serialized).expect("Failed to decode packet");
+        assert_eq!(deserialized.protocol_version, GOSSIP_PROTOCOL_VERSION);
 
         match deserialized.message {
             GossipMessage::StateRequest {
@@ -135,5 +196,28 @@ mod tests {
             }
             _ => panic!("Wrong message type after deserialization"),
         }
+    }
+
+    #[test]
+    fn test_version_mismatch_is_rejected() {
+        let message = GossipMessage::StateRequest {
+            requesting_node_id: NodeName::from("node-1").node_id(),
+            missing_keys: None,
+            response_addr: "127.0.0.1:8410".parse().unwrap(),
+        };
+        // Construct a packet with a stale version number (simulates a node
+        // running an old binary sending to a node running this binary).
+        let old_packet = GossipPacket {
+            protocol_version: 0, // wrong version
+            packet_id: 42,
+            message,
+        };
+        let serialized = old_packet.serialize().expect("Failed to serialize");
+
+        let result = GossipPacket::from_wire(&serialized);
+        assert!(
+            matches!(result, Err(GossipDecodeError::VersionMismatch { expected: GOSSIP_PROTOCOL_VERSION, got: 0 })),
+            "expected VersionMismatch error, got {:?}", result.map(|_| ())
+        );
     }
 }

--- a/src/node/gossip/messages.rs
+++ b/src/node/gossip/messages.rs
@@ -216,8 +216,15 @@ mod tests {
 
         let result = GossipPacket::from_wire(&serialized);
         assert!(
-            matches!(result, Err(GossipDecodeError::VersionMismatch { expected: GOSSIP_PROTOCOL_VERSION, got: 0 })),
-            "expected VersionMismatch error, got {:?}", result.map(|_| ())
+            matches!(
+                result,
+                Err(GossipDecodeError::VersionMismatch {
+                    expected: GOSSIP_PROTOCOL_VERSION,
+                    got: 0
+                })
+            ),
+            "expected VersionMismatch error, got {:?}",
+            result.map(|_| ())
         );
     }
 }

--- a/src/node/hashring/consistent_hashing.rs
+++ b/src/node/hashring/consistent_hashing.rs
@@ -35,20 +35,20 @@ pub fn get_neighbor_bucket(bucket_selected: u32, number_of_buckets: u32) -> (u32
         // Special case: only one bucket
         (0, 0)
     } else if number_of_buckets == 2 {
-        // Special case: two buckets - neighbor is the other one
+        // Special case: two buckets where neighbor is the other one
         if bucket_selected == 0 {
             (1, 1)
         } else {
             (0, 0)
         }
     } else if bucket_selected == 0 {
-        // bucket is first
+        // Bucket is first
         (number_of_buckets - 1, 1)
     } else if bucket_selected == number_of_buckets - 1 {
-        // bucket is last
+        // Bucket is last
         (bucket_selected - 1, 0)
     } else {
-        // bucket is somewhere in between
+        // Bucket is somewhere in between
         (bucket_selected - 1, bucket_selected + 1)
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -135,7 +135,7 @@ impl ClusterTopology {
     }
 
     /// Get nodes sorted by name (for consistent bucket assignment)
-    /// This is critical for hashring mode - all nodes must agree on the same order
+    /// This is critical for hashring mode because all nodes must agree on the same order.
     pub fn sorted_nodes(&self) -> Vec<(NodeName, SocketAddr)> {
         let mut nodes = self.all_nodes();
         nodes.sort_by(|a, b| a.0.cmp(&b.0));

--- a/src/transport/socket_pool_tcp.rs
+++ b/src/transport/socket_pool_tcp.rs
@@ -215,11 +215,7 @@ impl TcpSocketPool {
     }
 
     /// Open a new TCP connection to the given peer. A new connection is opened per request.
-    async fn open_connection(
-        &self,
-        node_id: NodeId,
-        socket_addr: SocketAddr,
-    ) -> Result<TcpStream> {
+    async fn open_connection(&self, node_id: NodeId, socket_addr: SocketAddr) -> Result<TcpStream> {
         match timeout(self.connection_timeout, TcpStream::connect(socket_addr)).await {
             Ok(Ok(stream)) => {
                 debug!(

--- a/src/transport/tcp_receiver.rs
+++ b/src/transport/tcp_receiver.rs
@@ -186,7 +186,7 @@ impl TcpReceiver {
                                 // Write response length prefix
                                 let len = response_data.len() as u32;
                                 if let Err(e) = stream.write_all(&len.to_be_bytes()).await {
-                                    // Connection closed by peer - expected in some cases
+                                    // Connection closed by peer is expected in some cases
                                     debug!(
                                         "Failed to write response length to {}: {}",
                                         peer_addr, e


### PR DESCRIPTION
This pull request introduces anti-entropy for the gossip protocol run-mode, which makes it so nodes can detect and recover from missed updates. 

The main goal here is to allow nodes to request and respond with full state dumps when vector clocks indicate missing information. 

This was partially implemented before and then I broke it and tore it out, so this is a fixed reimplementation.

**Gossip anti-entropy improvements:**

* Implemented targeted anti-entropy responses: When a node receives a `StateRequest`, it now responds directly to the requester with a full state dump using a new `send_gossip_packet_to` method, ensuring efficient and precise synchronization. 
* Heartbeat-driven anti-entropy: On receiving a heartbeat, the node compares vector clocks and, if it detects it is missing updates, proactively sends a `StateRequest` to the peer, triggering a full state sync.
* Simplified state request handling: The handler always returns the full state dump, ignoring requested keys, since CRDT merges are idempotent and extra data is harmless.
